### PR TITLE
Add VSCode HEART syntax highlighting

### DIFF
--- a/docs/SOUL_Language.md
+++ b/docs/SOUL_Language.md
@@ -214,7 +214,7 @@ float getAnArrayElement (float[] a, int index)      { return a.at (index); }
 To avoid confusion with fixed-size array indexes needing to use the `wrap` or `clamp` types, the `array[index]` syntax is not allowed on dynamic slices. Instead, you can use the following accessor methods:
 
 `array.at (index)`  - this casts the index argument to an integer (rounding down if it's a floating point value), wraps it if it's out-of-range, and returns the element at that index.
-`array.read (index)` - (essentially a synonum for `at`)
+`array.read (index)` - (essentially a synonym for `at`)
 `array.readLinearInterpolated (index)` - returns the linearly-interpolated value at the fractional position (after wrapping it if it's out-of-bounds). This us only available for arrays of floating-point types.
 
 Other interpolators such as LaGrange, Catmull-Rom, etc, may be added in future releases.
@@ -334,7 +334,7 @@ Where the runtime is providing an audio sample, you can add the annotation:
 external float[] audioFileData [[ resample: 48000 ]];
 ```
 
-...which will tell the runtime to pre-process the audio file (or buffer) provided so that it is resampled to the given rate. The runtime will use a high-queality interpolator and there'll be no run-time overhead once the code is running.
+...which will tell the runtime to pre-process the audio file (or buffer) provided so that it is resampled to the given rate. The runtime will use a high-quality interpolator and there'll be no run-time overhead once the code is running.
 
 You can also use the annotation 'sourceChannel' to pull out a specific channel from the file:
 

--- a/docs/SOUL_Overview.md
+++ b/docs/SOUL_Overview.md
@@ -56,7 +56,7 @@ We expect SOUL to be valuable to audio developers at all levels - from absolute 
 
 ### Who is the target audience for the SOUL platform architecture?
 
-At the high-end, SOUL will allow musicians to connect external accelarator devices to work on larger, more power-hungry sessions with much lower latency, while freeing up their laptop CPUs to handle the UI for their tools.
+At the high-end, SOUL will allow musicians to connect external accelerator devices to work on larger, more power-hungry sessions with much lower latency, while freeing up their laptop CPUs to handle the UI for their tools.
 
 At a more general consumer level, SOUL can improve power and battery life for mobile devices that support it with dedicated hardware. And by providing a flexible platform for implementing audio codecs, it could be a more future-proof replacement for silicon which is dedicated to performing decompression of specific common codec formats.
 
@@ -150,7 +150,7 @@ The main concepts involved in this API are **Performers** and **Venues**.
 
 - A *Performer* is an implementation of a JIT compiler which can be given a SOUL program and asked to synchronously render blocks of data.
 
-- A *Venue* is an independant device (e.g. a machine accessed via a network, or a separate process or driver running on your local machine), which can be sent a SOUL program to run, and then controlled remotely and asynchronously.
+- A *Venue* is an independent device (e.g. a machine accessed via a network, or a separate process or driver running on your local machine), which can be sent a SOUL program to run, and then controlled remotely and asynchronously.
 
 A developer can build a SOUL host which either compiles and runs SOUL synchronously inside its own process using a *performer*, or which dispatches the code to run remotely (and at low latency) in a suitable *venue*. Either way, using these APIs means that the programs are not limited to simple audio/MIDI i/o like the SOUL Patch format, and can have input and output channels containing any kind of data stream.
 

--- a/source/API/soul_patch/API/soul_patch_Library.h
+++ b/source/API/soul_patch/API/soul_patch_Library.h
@@ -25,7 +25,7 @@ static constexpr int currentLibraryAPIVersion = 0x1005;
 /**
     Dynamically opens and connects to the shared library containing the patch loader.
     You should only create a single instance of this class. and use it in an RAII
-    style, making sure it lives longer than all the objects that orginate from it.
+    style, making sure it lives longer than all the objects that originate from it.
 */
 struct SOULPatchLibrary
 {

--- a/source/README.md
+++ b/source/README.md
@@ -13,7 +13,7 @@ The low-level C++ source code for various compiler tasks is arranged as JUCE mod
 - `modules/soul_patch_loader` - this module implements a lot of the glue logic required to turn a `soul::Performer` into a set of COM classes which implement the SOUL Patch API
 
 - `API/soul_patch/API` - This contains the completely dependency-free C++ header-only COM base classes which define the SOUL Patch API
-- `API/soul_patch/helper_classes` - A set of header-only C++ utlities providing various client-side helpers for dealing with the SOUL Patch API. This includes classes to load patches as a `juce::AudioPluginInstance`
+- `API/soul_patch/helper_classes` - A set of header-only C++ utilities providing various client-side helpers for dealing with the SOUL Patch API. This includes classes to load patches as a `juce::AudioPluginInstance`
 
 ### Current Project Status
 

--- a/source/modules/soul_core/diagnostics/soul_Errors.h
+++ b/source/modules/soul_core/diagnostics/soul_Errors.h
@@ -179,7 +179,7 @@ namespace soul
     X(expectedUnqualifiedName,              "This name cannot have a namespace qualifier") \
     X(qualifierOnGeneric,                   "Generic function types must be a non-qualified identifier") \
     X(tooManyParameters,                    "Too many function parameters") \
-    X(tooManyInitialisers,                  "Initialiser list exceeeds max length limit") \
+    X(tooManyInitialisers,                  "Initialiser list exceeds max length limit") \
     X(cannotPassConstAsNonConstRef,         "Cannot pass a const value as a non-const reference") \
     X(assignmentInsideExpression,           "Assignment is not allowed inside an expression") \
     X(propertiesOutsideProcessor,           "Processor properties are only valid inside a processor declaration") \

--- a/tools/editors/vs_code_extension/heart/.vscode/launch.json
+++ b/tools/editors/vs_code_extension/heart/.vscode/launch.json
@@ -1,0 +1,18 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/tools/editors/vs_code_extension/heart/language-configuration.json
+++ b/tools/editors/vs_code_extension/heart/language-configuration.json
@@ -1,0 +1,28 @@
+{
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "#",
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    // symbols that that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/tools/editors/vs_code_extension/heart/package.json
+++ b/tools/editors/vs_code_extension/heart/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "heart",
+    "displayName": "heart",
+    "description": "HEART language support",
+    "version": "0.0.1",
+    "engines": {
+        "vscode": "^1.32.0"
+    },
+    "categories": [
+        "Programming Languages"
+    ],
+    "contributes": {
+        "languages": [{
+            "id": "heart",
+            "aliases": ["HEART", "heart"],
+            "extensions": [".heart",".hearttest"],
+            "configuration": "./language-configuration.json"
+        }],
+        "grammars": [{
+            "language": "heart",
+            "scopeName": "source.heart",
+            "path": "./syntaxes/heart.tmLanguage.json"
+        }]
+    }
+}

--- a/tools/editors/vs_code_extension/heart/syntaxes/heart.tmLanguage.json
+++ b/tools/editors/vs_code_extension/heart/syntaxes/heart.tmLanguage.json
@@ -1,0 +1,163 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "HEART",
+	"scopeName": "source.heart",
+	"patterns": [
+		{
+			"name": "keyword.control.heart",
+			"match": "\\b(branch_if|branch|return)\\b"
+		},
+		{
+			"name": "storage.type.heart",
+			"match": "\\b(const|void|int|int32|int64|float|float32|float64|fixed|bool|string|node|event|stream|value|wrap|clamp|external)\\b"
+		},
+		{
+			"name": "entity.name.type.heart",
+			"match": "\\b(let|var|graph|processor|namespace|struct|function|enum|input|output|connection|import)\\b"
+		},
+		{
+			"name": "entity.name.function.heart",
+			"match": "\\b(read|write|advance|cast|call|add|multiply|subtract|divide|modulo|bitwiseOr|bitwiseAnd|bitwiseXor|logicalOr|logicalAnd|equals|notEquals|lessThan|lessThanOrEqual|greaterThan|greaterThanOrEqual|leftShift|rightShift|rightShiftUnsigned|negate|logicalNot|bitwiseNot)\\b"
+		},
+		{
+			"name": "entity.name.tag.heart",
+			"match": "\\b(none|latch|linear|sinc|fast|best)\\b"
+		},
+		{
+			"name": "entity.name.section.heart",
+			"match": "([@*])\\w+"
+		},
+		{
+			"name": "variable.other.heart",
+			"match": "([$*])\\w+"
+		},
+		{
+			"name": "invalid.illegal.heart",
+			"match": "\\b(try|catch|throw|class|default|operator|switch|case)\\b"
+		},
+		{
+			"name": "comment.line.number-sign.heart",
+			"begin": "#",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.comment.cpp"
+				}
+			},
+			"end": "(?=\\n)",
+			"patterns": [
+				{
+					"match": "(\\\\)\\n"
+				}
+			]
+		},
+		{
+			"match": "->|<-",
+			"name": "keyword.other.heart"
+		},
+		{
+			"match": "<<|>>",
+			"name": "keyword.other.heart"
+		},
+		{
+			"match": "\\.|::",
+			"name": "punctuation.separator.heart"
+		},
+		{
+			"match": ";",
+			"name": "punctuation.terminator.heart"
+		},
+		{
+			"match": "=",
+			"name": "keyword.operator.assignment.heart"
+		},
+		{
+			"match": "%|\\*|/|-|\\+",
+			"name": "keyword.operator.heart"
+		},
+		{
+			"match": "\\b(true|false)\\b",
+			"name": "constant.language.heart"
+		},
+		{
+			"match": "\\b((0(x|X)[0-9a-fA-F]([0-9a-fA-F']*[0-9a-fA-F])?)|(0(b|B)[01]([01']*[01])?)|(([0-9]([0-9']*[0-9])?\\.?[0-9]*([0-9']*[0-9])?)|(\\.[0-9]([0-9']*[0-9])?))((e|E)(\\+|-)?[0-9]([0-9']*[0-9])?)?)(f)?|([0-9]*([0-9']*[0-9])?(L))\\b",
+			"name": "constant.numeric.heart"
+		},
+		{
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.begin.bracket.round.heart"
+				}
+			},
+			"end": "\\)|(?=//)|(?=/\\*(?!.*\\\\\\s*\\n))|(?<!\\\\)(?=\\n)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.parens.end.bracket.round.heart"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#preprocessor-rule-conditional-line"
+				}
+			]
+		},
+		{
+			"begin": "{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.block.begin.bracket.curly.heart"
+				}
+			},
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.block.end.bracket.curly.heart"
+				}
+			},
+			"name": "meta.block.c",
+			"patterns": [
+				{
+					"include": "#block_innards"
+				}
+			]
+		},
+		{
+			"match": "(\\[)|(\\])",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.begin.bracket.square.heart"
+				},
+				"2": {
+					"name": "punctuation.definition.end.bracket.square.heart"
+				}
+			}
+		},
+		{
+			"match": "(\\[\\[)|(\\]\\])",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.block.begin.bracket.square.heart"
+				},
+				"2": {
+					"name": "punctuation.definition.block.end.bracket.square.heart"
+				}
+			}
+		},
+		{
+			"name": "string.quoted.double.heart",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.heart",
+					"match": "\\\\."
+				}
+			]
+		},
+		{
+			"name": "keyword.control.directive.heart",
+			"begin": "^##",
+			"end": "(?=\\n)"
+		}
+	]
+}

--- a/tools/editors/vs_code_extension/soul/syntaxes/soul.tmLanguage.json
+++ b/tools/editors/vs_code_extension/soul/syntaxes/soul.tmLanguage.json
@@ -9,7 +9,7 @@
 		},
 		{
 			"name": "storage.type.soul",
-			"match": "\\b(const|void|int|int32|int64|float|float32|float64|fixed|bool|string|event|wrap|clamp|external)\\b"
+			"match": "\\b(const|void|int|int32|int64|float|float32|float64|fixed|bool|string|event|stream|value|wrap|clamp|external)\\b"
 		},
 		{
 			"name": "entity.name.type.soul",
@@ -110,7 +110,7 @@
 			"name": "constant.language.soul"
 		},
 		{
-			"match": "\\b((0(x|X)[0-9a-fA-F]([0-9a-fA-F']*[0-9a-fA-F])?)|(0(b|B)[01]([01']*[01])?)|(([0-9]([0-9']*[0-9])?\\.?[0-9]*([0-9']*[0-9])?)|(\\.[0-9]([0-9']*[0-9])?))((e|E)(\\+|-)?[0-9]([0-9']*[0-9])?)?)(F|f)?\\b",
+			"match": "\\b((0(x|X)[0-9a-fA-F]([0-9a-fA-F']*[0-9a-fA-F])?)|(0(b|B)[01]([01']*[01])?)|(([0-9]([0-9']*[0-9])?\\.?[0-9]*([0-9']*[0-9])?)|(\\.[0-9]([0-9']*[0-9])?))((e|E)(\\+|-)?[0-9]([0-9']*[0-9])?)?)((_)?f((32|64)?))?|([0-9]*([0-9']*[0-9])?((_)?(L|i(32|64))))\\b",
 			"name": "constant.numeric.soul"
 		},
 		{


### PR DESCRIPTION
Picking those low-hanging fruit:

* 🥭: Add HEART syntax highlighting for VSCode.
* 🍉: Add numeric literals (`i32`, `_i64`, ...) and a couple missing types (`stream`, `value`) to SOUL syntax highlighting for VSCode.
* 🍒: Fix some tyops.
